### PR TITLE
universal_connection 

### DIFF
--- a/service/server.hpp
+++ b/service/server.hpp
@@ -22,7 +22,7 @@
 #include <signal.h>
 #include <utility>
 #include <memory>
-#include "connection.hpp"
+#include "transient_connection.hpp"
 #include "connection_manager.hpp"
 #include "request_handler.hpp"
  
@@ -30,7 +30,7 @@ namespace http {
 namespace server {
  
 /// The top-level class of the HTTP server.
-template<typename request_handler_type, template<class> class  connection_impl = connection>
+template<typename request_handler_type, template<class> class  connection_impl = transient_connection>
 class server
 {
 public:

--- a/service/transient_connection.hpp
+++ b/service/transient_connection.hpp
@@ -32,18 +32,18 @@ template<class> class connection_manager;
  
 /// Represents a single connection from a client.
 template <typename request_handler_type>
-class connection
-  : public std::enable_shared_from_this<connection<request_handler_type> >
+class transient_connection
+  : public std::enable_shared_from_this<transient_connection<request_handler_type> >
 {
-    typedef connection<request_handler_type> self_type;
-    typedef std::shared_ptr<self_type> self_type_ptr;
-    typedef connection_manager<self_type_ptr> connection_manager_type;
+    using self_type     = transient_connection<request_handler_type> ;
+    using self_type_ptr = std::shared_ptr<self_type> ;
+    using connection_manager_type = connection_manager<self_type_ptr> ;
 public:
-  connection(const connection&) = delete;
-  connection& operator=(const connection&) = delete;
+  transient_connection(const transient_connection&) = delete;
+  transient_connection& operator=(const transient_connection&) = delete;
  
   /// Construct a connection with the given socket.
-  explicit connection(boost::asio::ip::tcp::socket socket,
+  explicit transient_connection(boost::asio::ip::tcp::socket socket,
       connection_manager_type& manager, request_handler_type& handler)
   : socket_(std::move(socket)),
     connection_manager_(manager),


### PR DESCRIPTION
- connection.hpp was by default transient therefore was renamed to transient_connection.hpp 
- need to add universal_connection.hpp to handle HTTP 1.1 /1.0 and close/keep-alive for ability to build web server from CRUD